### PR TITLE
Add timeout for parallel processing.

### DIFF
--- a/fainder/execution/parallel_processing.py
+++ b/fainder/execution/parallel_processing.py
@@ -238,12 +238,16 @@ class ParallelHistogramProcessor:
             )
 
         combined_results = []
-        for future in as_completed(futures):
-            try:
-                result = future.result()
-                combined_results.append(result)
-            except Exception as e:
-                logger.error(f"Worker failed with exception: {e}")
+        try:
+            for future in as_completed(futures, 300):
+                try:
+                    result = future.result()
+                    combined_results.append(result)
+                except Exception as e:
+                    logger.error(f"Worker failed with exception: {e}")
+        except TimeoutError:
+            logger.error("timeout in ParallelProcessor")
+            return []
 
         return (
             np.concatenate(combined_results) if combined_results else np.array([], dtype=np.uint32)

--- a/fainder/execution/parallel_processing.py
+++ b/fainder/execution/parallel_processing.py
@@ -247,7 +247,7 @@ class ParallelHistogramProcessor:
                     logger.error(f"Worker failed with exception: {e}")
         except TimeoutError:
             logger.error("timeout in ParallelProcessor")
-            return []
+            return np.array([], dtype=np.uint32)
 
         return (
             np.concatenate(combined_results) if combined_results else np.array([], dtype=np.uint32)


### PR DESCRIPTION
Added a timeout of 300 seconds to parallel processing.
While testing, I found that a timeout is sometimes necessary; I'm not sure why, but it occurs infrequently.
The length of the timeout could be changed, of course. The error could instead of returning an empty array be re-raised. 
